### PR TITLE
:bug: Fix deck name using actual card variant

### DIFF
--- a/analysis/src/utils/get-deck-name.ts
+++ b/analysis/src/utils/get-deck-name.ts
@@ -212,7 +212,7 @@ const getDeckName = (deck: Deck): string | null => {
     }
   }
 
-  // Then try matching with at least 1 copy of each card
+  // Then try matching with at least 1 copy of the primary card; secondary-card matches still require 2 copies
   for (const criteria of ARCHITYPES) {
     const { primary, secondary } = criteria;
     for (const secondaryCard of secondary) {

--- a/analysis/src/utils/get-deck-name.ts
+++ b/analysis/src/utils/get-deck-name.ts
@@ -176,6 +176,21 @@ const hasAllCards = (
 };
 
 /**
+ * Finds the specific card from a match criteria that is actually present in the deck.
+ * Falls back to the first entry if none are found.
+ */
+const getMatchedCard = (cards: Deck["cards"], match: CardNameType): string => {
+  const cardStrings = new Set(cards.map((card) => cardToString(card)));
+  const matchArray = Array.isArray(match) ? match : [match];
+  for (const cardName of matchArray) {
+    if (cardStrings.has(`2 ${cardName}`) || cardStrings.has(`1 ${cardName}`)) {
+      return cardName;
+    }
+  }
+  return matchArray[0];
+};
+
+/**
  * Attempts to find a matching deck name based on the deck's cards
  * @param deck The deck to find a name for
  * @returns The formatted deck name if found, null otherwise
@@ -188,32 +203,26 @@ const getDeckName = (deck: Deck): string | null => {
     const { primary, secondary } = criteria;
     for (const secondaryCard of secondary) {
       if (hasAllCards(cards, primary, true, secondaryCard)) {
-        const primaryMatch = Array.isArray(primary) ? primary : [primary];
-        const secondaryMatch = Array.isArray(secondaryCard) ? secondaryCard : [secondaryCard];
-        const match = [primaryMatch[0], secondaryMatch[0]];
+        const match = [getMatchedCard(cards, primary), getMatchedCard(cards, secondaryCard)];
         return formatName(cards, match);
       }
     }
     if (hasAllCards(cards, primary, true)) {
-      const primaryMatch = Array.isArray(primary) ? [primary[0]] : [primary];
-      return formatName(cards, primaryMatch);
+      return formatName(cards, [getMatchedCard(cards, primary)]);
     }
   }
 
-  // First try matching with exactly 2 copies of each card
+  // Then try matching with at least 1 copy of each card
   for (const criteria of ARCHITYPES) {
     const { primary, secondary } = criteria;
     for (const secondaryCard of secondary) {
       if (hasAllCards(cards, primary, false, secondaryCard)) {
-        const primaryMatch = Array.isArray(primary) ? primary : [primary];
-        const secondaryMatch = Array.isArray(secondaryCard) ? secondaryCard : [secondaryCard];
-        const match = [primaryMatch[0], secondaryMatch[0]];
+        const match = [getMatchedCard(cards, primary), getMatchedCard(cards, secondaryCard)];
         return formatName(cards, match);
       }
     }
     if (hasAllCards(cards, primary, false)) {
-      const primaryMatch = Array.isArray(primary) ? [primary[0]] : [primary];
-      return formatName(cards, primaryMatch);
+      return formatName(cards, [getMatchedCard(cards, primary)]);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes a bug in `analysis/src/utils/get-deck-name.ts` where decks with architypes that listed multiple card variants (e.g. `MAGNEZONE = ["Magnezone ex B3 54", "Magnezone A2 53", "Magnezone B1a 26"]`) were always named after the first entry in the array, regardless of which variant the deck actually contained.

A deck running `Magnezone A2 53` was being labeled `magnezone-ex-b3-054` instead of `magnezone-a2-053`, which is what the failing unit test caught.

## Changes

- Added a `getMatchedCard` helper that scans the deck and returns the specific architype entry that's actually present.
- Used it for both the primary and secondary card when constructing the match passed to `formatName`.
- Cleaned up the misleading "First try matching" comment on the second loop (it's the second pass, with `requireTwo=false`).

## Test plan

- [x] `yarn jest` in `analysis/`: 17 suites, 38 tests, all green (the previously failing `get-deck-name` test now passes).
- [ ] Regenerate downstream deck-name data, since previously persisted names for non-first-variant matches will change (e.g., `magnezone-ex-b3-054` -> `magnezone-a2-053`).


Made with [Cursor](https://cursor.com)