### PR TITLE
Enable AdSense ads (set slot IDs + turn on ADS_ENABLED)

### DIFF
--- a/src/ads/adsConfig.ts
+++ b/src/ads/adsConfig.ts
@@ -8,7 +8,7 @@
 // Flip this to true once the AdSense account is approved and all ADSENSE_SLOTS
 // below have their slot IDs filled in. Controls whether real ads are served in
 // production; dev always shows placeholders regardless of this flag.
-export const ADS_ENABLED = false;
+export const ADS_ENABLED = true;
 
 // In local development we render labelled placeholder boxes instead of loading
 // the real ad network, so the layout/spacing can be verified without third
@@ -24,10 +24,10 @@ export const ADSENSE_CLIENT = "ca-pub-3547629432918335";
 // once approved, then paste the numeric slot IDs here. Filling these plus
 // ADSENSE_CLIENT + the ADS_ENABLED flag is all that's needed to go live.
 export const ADSENSE_SLOTS = {
-  anchor: "",
-  landing: "",
-  tierList: "",
-  deck: "",
+  anchor: "6391402118",
+  landing: "2452157107",
+  tierList: "9572403149",
+  deck: "8781910120",
 } as const;
 
 export type AdPlacement = keyof typeof ADSENSE_SLOTS;


### PR DESCRIPTION
AdSense account is approved 🎉 — this turns ads on.

## Changes
- Fill in the four Display ad-unit slot IDs in `ADSENSE_SLOTS` (anchor, landing, tier-list, deck).
- Set `ADS_ENABLED = true`.

That's the only change; everything else (publisher ID, script, ads.txt, placements, premium gating, prerendering) was already in place.

## Behaviour after deploy
- Free users see the sticky anchor + one in-content unit (per page), only after content loads.
- Premium users see **zero ads**.
- Ads are **not** baked into the prerendered static HTML (verified); they render client-side for free users only. The AdSense script + SEO content remain in the static HTML.

## Test plan
- [x] `yarn build` compiles + react-snap prerenders all 5 routes
- [x] Verified prerendered `/tier-list` has no ad `<ins>` baked in, but keeps the AdSense script + SEO content
- [ ] After deploy: signed-out shows anchor + in-content with real ads within a few minutes
- [ ] After deploy: signed-in Premium shows no ads
- [ ] Confirm Auto ads OFF + GDPR consent message published in AdSense
- [ ] Impressions accruing in AdSense over 24–48h

Made with [Cursor](https://cursor.com)