### PR TITLE
Reprice Premium to $3/mo + $18/yr, repackage as "remove ads + unlock everything"

### DIFF
--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -8,8 +8,30 @@ export const EXPANSIONS_URL =
 export const GITHUB_URL =
   "https://github.com/chase-manning/pokemon-tcg-pocket-tier-list";
 export const TWITTER_URL = "https://x.com/pocketdecks";
-export const MONTHLY_PRICE_ID = "price_1RXU5FBIHa8JB5eJAkWt6cRp";
-export const YEARLY_PRICE_ID = "price_1RXgpJBIHa8JB5eJKys9UK8W";
+// Stripe Price IDs for the Premium subscription.
+//
+// Stripe prices are immutable — the amount of an existing price cannot be
+// edited. To reprice Premium we create NEW prices in Stripe ($3/mo, $18/yr)
+// and swap the IDs below. Leave the OLD $1/mo and $6/yr prices ACTIVE in
+// Stripe (just no longer referenced here): existing subscribers stay on their
+// original price until they cancel, which is exactly how grandfathering works.
+// Do NOT use Stripe's "update subscriptions to this price" migration tools.
+//
+// The 7-day free trial is configured on each NEW price in Stripe
+// (trial_period_days = 7). The checkout applies it automatically because the
+// extension defaults trial_from_plan to true — no extra code needed here.
+//
+// Legacy prices (kept active in Stripe for grandfathered subscribers, no longer
+// referenced here): $1/mo price_1RXU5FBIHa8JB5eJAkWt6cRp, $6/yr
+// price_1RXgpJBIHa8JB5eJKys9UK8W.
+export const MONTHLY_PRICE_ID = "price_1TeE4nBIHa8JB5eJZKGmmZSM"; // $3/mo
+export const YEARLY_PRICE_ID = "price_1TeE57BIHa8JB5eJbycZcro1"; // $18/yr
+
+// Free trial length (days) applied to new subscriptions. The Firebase Stripe
+// extension reads `trial_period_days` from the checkout session document root
+// and maps it to subscription_data.trial_period_days — so the trial is set
+// here in code, not on the Stripe price. Set to 0 to disable.
+export const FREE_TRIAL_DAYS = 7;
 export const MANAGE_SUBSCRIPTION_URL =
   "https://billing.stripe.com/p/login/4gM9ASeDk2QcaKq2Y957W00";
 export const FREE_DECK_AMOUNT = 30;

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -17,9 +17,10 @@ export const TWITTER_URL = "https://x.com/pocketdecks";
 // original price until they cancel, which is exactly how grandfathering works.
 // Do NOT use Stripe's "update subscriptions to this price" migration tools.
 //
-// The 7-day free trial is configured on each NEW price in Stripe
-// (trial_period_days = 7). The checkout applies it automatically because the
-// extension defaults trial_from_plan to true — no extra code needed here.
+// The 7-day free trial is set in code (see FREE_TRIAL_DAYS) by passing
+// `trial_period_days` on the checkout session document root; the extension
+// forwards it to subscription_data.trial_period_days. No Stripe price
+// configuration is required.
 //
 // Legacy prices (kept active in Stripe for grandfathered subscribers, no longer
 // referenced here): $1/mo price_1RXU5FBIHa8JB5eJAkWt6cRp, $6/yr

--- a/src/components/Premium.tsx
+++ b/src/components/Premium.tsx
@@ -190,6 +190,7 @@ const Premium = ({
   );
 
   const startCheckout = async (price: string, plan: "monthly" | "yearly") => {
+    if (loadingPlan !== null) return;
     setLoadingPlan(plan);
     try {
       // The extension reads `trial_period_days` from the checkout session

--- a/src/components/Premium.tsx
+++ b/src/components/Premium.tsx
@@ -1,6 +1,7 @@
 import Button from "./Button";
 import { createCheckoutSession } from "@invertase/firestore-stripe-payments";
 import {
+  FREE_TRIAL_DAYS,
   MANAGE_SUBSCRIPTION_URL,
   MONTHLY_PRICE_ID,
   YEARLY_PRICE_ID,
@@ -127,6 +128,46 @@ const ButtonWrapper = styled.div`
   }
 `;
 
+// Monthly is offered as a quiet secondary option so the annual plan reads as
+// the default choice (better LTV / conversion).
+const SecondaryPlan = styled.button`
+  align-self: center;
+  cursor: pointer;
+  font-size: 1.5rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  text-decoration: underline;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const TrialNote = styled.p`
+  margin: 0;
+  text-align: center;
+  font-size: 1.4rem;
+  color: rgba(255, 255, 255, 0.55);
+`;
+
+const Headline = styled.h2`
+  margin: 0 0 0.5rem;
+  text-align: center;
+  font-size: 2.8rem;
+  font-weight: 700;
+  color: var(--main);
+
+  @media (max-width: 900px) {
+    font-size: 2.2rem;
+  }
+`;
+
 interface Props {
   showUpsell?: boolean;
   // "link" renders a compact "Remove ads" text trigger (used by the ad anchor)
@@ -144,7 +185,29 @@ const Premium = ({
   const isPremium = useIsPremium();
   const { user, signInWithGoogle } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
+  const [loadingPlan, setLoadingPlan] = useState<"monthly" | "yearly" | null>(
+    null
+  );
+
+  const startCheckout = async (price: string, plan: "monthly" | "yearly") => {
+    setLoadingPlan(plan);
+    try {
+      // The extension reads `trial_period_days` from the checkout session
+      // document root (it writes our params to Firestore verbatim) and maps it
+      // to subscription_data.trial_period_days. The typed SDK omits the field,
+      // so it's passed through with a cast.
+      const session = await createCheckoutSession(payments, {
+        price,
+        ...(FREE_TRIAL_DAYS > 0
+          ? { trial_period_days: FREE_TRIAL_DAYS }
+          : {}),
+      } as Parameters<typeof createCheckoutSession>[1]);
+      window.location.assign(session.url);
+    } catch (error) {
+      console.error(error);
+      setLoadingPlan(null);
+    }
+  };
 
   if (isPremium === null) return null;
 
@@ -185,6 +248,7 @@ const Premium = ({
           setIsOpen(false);
         }}
       >
+        <Headline>{t("premium.headline")}</Headline>
         <ComparisonTable>
           <thead>
             <tr>
@@ -284,32 +348,18 @@ const Premium = ({
             <>
               <Button
                 wide
-                isLoading={isLoading}
-                action={async () => {
-                  setIsLoading(true);
-                  const session = await createCheckoutSession(payments, {
-                    price: MONTHLY_PRICE_ID,
-                  });
-                  window.location.assign(session.url);
-                  setIsLoading(false);
-                }}
-              >
-                {t("premium.getPremiumMonthly")}
-              </Button>
-              <Button
-                wide
-                isLoading={isLoading}
-                action={async () => {
-                  setIsLoading(true);
-                  const session = await createCheckoutSession(payments, {
-                    price: YEARLY_PRICE_ID,
-                  });
-                  window.location.assign(session.url);
-                  setIsLoading(false);
-                }}
+                isLoading={loadingPlan === "yearly"}
+                action={() => startCheckout(YEARLY_PRICE_ID, "yearly")}
               >
                 {t("premium.getPremiumYearly")}
               </Button>
+              <SecondaryPlan
+                disabled={loadingPlan !== null}
+                onClick={() => startCheckout(MONTHLY_PRICE_ID, "monthly")}
+              >
+                {t("premium.getPremiumMonthly")}
+              </SecondaryPlan>
+              <TrialNote>{t("premium.freeTrial")}</TrialNote>
             </>
           ) : (
             <Button

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -91,8 +91,10 @@
     "description": "Holen Sie sich Premium, um alle Funktionen freizuschalten und das Projekt zu unterstützen.",
     "signIn": "Anmelden für Premium",
     "getPremium": "Premium erhalten",
-    "getPremiumMonthly": "Premium für 1€/Monat",
-    "getPremiumYearly": "Premium für 6€/Jahr (50% Rabatt!)",
+    "getPremiumMonthly": "oder 3€/Monat",
+    "getPremiumYearly": "Premium für 18€/Jahr (50% sparen)",
+    "freeTrial": "7 Tage kostenlos testen · Jederzeit kündbar",
+    "headline": "Werbung entfernen & alles freischalten",
     "manageSubscription": "Abonnement verwalten",
     "features": {
       "title": "Funktionen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -4,8 +4,10 @@
     "description": "Get Premium to unlock all features and support the project.",
     "signIn": "Sign in to get Premium",
     "getPremium": "Get Premium",
-    "getPremiumMonthly": "Get Premium $1/month",
-    "getPremiumYearly": "Get Premium $6/year (50% off!)",
+    "getPremiumMonthly": "or $3/month",
+    "getPremiumYearly": "Get Premium — $18/year (Save 50%)",
+    "freeTrial": "7-day free trial included · Cancel anytime",
+    "headline": "Remove ads & unlock everything",
     "manageSubscription": "Manage Subscription",
     "features": {
       "title": "Features",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -91,8 +91,10 @@
     "description": "Obtén Premium para desbloquear todas las funciones y apoyar el proyecto.",
     "signIn": "Inicia sesión para obtener Premium",
     "getPremium": "Obtener Premium",
-    "getPremiumMonthly": "Obtener Premium $1/mes",
-    "getPremiumYearly": "Obtener Premium $6/año (¡50% de descuento!)",
+    "getPremiumMonthly": "o $3/mes",
+    "getPremiumYearly": "Obtener Premium — $18/año (¡Ahorra 50%!)",
+    "freeTrial": "Incluye 7 días de prueba gratis · Cancela cuando quieras",
+    "headline": "Elimina los anuncios y desbloquea todo",
     "manageSubscription": "Gestionar Suscripción",
     "features": {
       "title": "Características",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -91,8 +91,10 @@
     "description": "Obtenez Premium pour débloquer toutes les fonctionnalités et soutenir le projet.",
     "signIn": "Connectez-vous pour obtenir Premium",
     "getPremium": "Obtenir Premium",
-    "getPremiumMonthly": "Obtenir Premium 1€/mois",
-    "getPremiumYearly": "Obtenir Premium 6€/an (50% de réduction !)",
+    "getPremiumMonthly": "ou 3€/mois",
+    "getPremiumYearly": "Obtenir Premium — 18€/an (économisez 50%)",
+    "freeTrial": "Essai gratuit de 7 jours inclus · Annulez à tout moment",
+    "headline": "Supprimez les publicités et débloquez tout",
     "manageSubscription": "Gérer l'abonnement",
     "features": {
       "title": "Fonctionnalités",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -97,8 +97,10 @@
     "description": "すべての機能をアンロックし、プロジェクトをサポートするためにプレミアムを取得してください。",
     "signIn": "プレミアムを取得するにはサインインしてください",
     "getPremium": "プレミアムを取得",
-    "getPremiumMonthly": "プレミアムを月額$1で取得",
-    "getPremiumYearly": "プレミアムを年間$6で取得（50%オフ！）",
+    "getPremiumMonthly": "または月額$3",
+    "getPremiumYearly": "プレミアムを年間$18で取得（50%オフ！）",
+    "freeTrial": "7日間の無料トライアル付き · いつでもキャンセル可能",
+    "headline": "広告を非表示にしてすべてを解放",
     "manageSubscription": "サブスクリプション管理",
     "features": {
       "title": "機能",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -97,8 +97,10 @@
     "description": "모든 기능을 잠금 해제하고 프로젝트를 지원하려면 프리미엄을 구독하세요.",
     "signIn": "프리미엄을 구독하려면 로그인하세요",
     "getPremium": "프리미엄 구독",
-    "getPremiumMonthly": "프리미엄 월 $1",
-    "getPremiumYearly": "프리미엄 연 $6 (50% 할인!)",
+    "getPremiumMonthly": "또는 월 $3",
+    "getPremiumYearly": "프리미엄 연 $18 (50% 할인!)",
+    "freeTrial": "7일 무료 체험 포함 · 언제든지 취소 가능",
+    "headline": "광고 제거 & 모든 기능 잠금 해제",
     "manageSubscription": "구독 관리",
     "features": {
       "title": "기능",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -91,8 +91,10 @@
     "description": "获取高级会员以解锁所有功能并支持项目发展。",
     "signIn": "登录以获取高级会员",
     "getPremium": "获取高级会员",
-    "getPremiumMonthly": "高级会员 $1/月",
-    "getPremiumYearly": "高级会员 $6/年（50%优惠！）",
+    "getPremiumMonthly": "或 $3/月",
+    "getPremiumYearly": "高级会员 $18/年（省50%！）",
+    "freeTrial": "包含7天免费试用 · 随时取消",
+    "headline": "去除广告，解锁全部功能",
     "manageSubscription": "管理订阅",
     "features": {
       "title": "功能",


### PR DESCRIPTION
## Summary

Repositions Premium for better monetisation (per growth recommendation): triples the price while making **ad removal** the headline value prop, and adds standard conversion levers (annual default + free trial).

- **Reprice**: `$1/mo + $6/yr` → **`$3/mo + $18/yr`** (annual = 50% off vs monthly). Still the cheapest in the category (matches OP.GG, undercuts U.GG). New Stripe price IDs swapped into `constants.ts`.
- **Grandfathering**: the legacy `$1/$6` prices stay **active** in Stripe (just no longer referenced), so existing subscribers keep their original rate until they cancel. No subscription migration is performed.
- **7-day free trial**: set in code via `trial_period_days` at the checkout-session root (the Firebase Stripe extension forwards it to `subscription_data.trial_period_days`). Controlled by the new `FREE_TRIAL_DAYS` constant — no Stripe price configuration needed. Verified on Stripe Checkout ("7 days free, then US$3.00/month").
- **Annual default**: annual is now the primary CTA; monthly is demoted to a quiet secondary link, with a "7-day free trial · Cancel anytime" note.
- **Repackaging**: adds a **"Remove ads & unlock everything"** headline to the upsell popup (Remove Ads is already the #1 feature row).
- **Styling fix**: secondary link + trial note use muted neutral text instead of the salmon-red `--s` (which read like a validation error under the button).
- **i18n**: price + trial + headline copy updated across all 7 locales (en, es, fr, de, ja, ko, zh-CN).

## Notes / risks

- Display copy and price IDs ship together here, so the charged amount always matches the UI.
- The trial depends on the installed Firebase Stripe extension supporting root-level `trial_period_days` — already confirmed working via a live Stripe Checkout test.

## Test plan

- [x] Stripe Checkout shows a 7-day free trial then $3/mo (annual: $18/yr).
- [x] Popup renders annual primary + secondary monthly + trial note; copy correct.
- [x] `yarn` dev build compiles; lint clean; all locale JSON valid.
- [ ] After merge (auto-deploys via Firebase Hosting Action): smoke-test live checkout for both plans and confirm an existing subscriber is unaffected.

Made with [Cursor](https://cursor.com)