### PR TITLE
Fix premium not unlocking for trialing subscribers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ analysis/data
 .env
 
 update-decks.sh
+.cursor/settings.json

--- a/src/app/use-is-premium.ts
+++ b/src/app/use-is-premium.ts
@@ -21,8 +21,16 @@ const useIsPremium = () => {
       setIsPremium(false);
       return;
     }
+    // Count subscriptions that grant Premium access. "trialing" is essential:
+    // new sign-ups start a 7-day free trial, so their subscription status is
+    // "trialing" (not "active") until the trial ends and the first invoice is
+    // paid. Filtering on "active" alone makes trialing users look non-premium,
+    // which re-shows the upsell and sends them back through Stripe checkout —
+    // some end up with duplicate subscriptions. "past_due" keeps access during
+    // Stripe's payment-retry grace period instead of yanking it on a single
+    // failed renewal.
     getCurrentUserSubscriptions(payments, {
-      status: "active", // Optional: filter by status
+      status: ["active", "trialing", "past_due"],
     })
       .then((subscriptions) => {
         setIsPremium(subscriptions.length > 0);


### PR DESCRIPTION
## Summary

The Premium reprice PR (#15, now merged) added a **7-day free trial** to new subscriptions, but the premium check in `useIsPremium` only counted subscriptions with Stripe status `"active"`.

A subscription in a free trial has status **`"trialing"`**, not `"active"` — Stripe only flips it to `active` after the trial ends and the first invoice is paid. So new subscribers were correctly subscribed but appeared **non-premium**: the upsell kept reappearing and re-sent them through Stripe checkout. Some users ended up with **duplicate subscriptions**.

This is the single gate for all premium UI (ad removal, tier list, deck page, account, filters), so the one filter broke premium everywhere at once.

### Validated against live Stripe data
- Every subscription on the new prices ($3/mo, $18/yr) is currently `trialing`; every older subscription (pre-trial $1/$6 prices) is `active`.
- One customer has **two `trialing` subscriptions created ~60s apart** — a real user caught in the "it didn't register me, so I signed up again" loop.

## Changes
- `src/app/use-is-premium.ts`: count `["active", "trialing", "past_due"]` as Premium.
  - `trialing` — fixes the reported bug (trial users now unlock premium).
  - `past_due` — preserves access during Stripe's payment-retry grace period instead of revoking on a single failed renewal.
- `.gitignore`: ignore `.cursor/settings.json`.

## Test plan
- [ ] Sign up with a fresh account → premium unlocks immediately (status `trialing`), upsell no longer reappears, no second checkout.
- [ ] Existing `active` subscriber still sees premium.
- [ ] Signed-out / no-subscription user still sees the free experience.

## Follow-ups (not in this PR)
- Clean up existing duplicate trial subscriptions (e.g. the customer with two overlapping trials) to avoid double-charging when trials convert.
- Optional: swap one-shot `getCurrentUserSubscriptions` for `onCurrentUserSubscriptionUpdate` so the UI flips to premium in realtime without a refresh after checkout.

Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)