### PR TITLE
fix(ci): pin Node to 24.16.0 for Firebase deploy

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -23,7 +23,7 @@ jobs:
       # Pin Node for the firebase-tools subprocess only: the runner default
       # Node breaks node-fetch@v2 (premature close on every request), but the
       # legacy react-snap/puppeteer in the build step needs the default Node.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.16.0
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24.16.0
       - run: yarn
       - run: yarn build
         env:
@@ -23,6 +20,12 @@ jobs:
           REACT_APP_FIREBASE_STORAGE_BUCKET: ${{ secrets.REACT_APP_FIREBASE_STORAGE_BUCKET }}
           REACT_APP_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.REACT_APP_FIREBASE_MESSAGING_SENDER_ID }}
           REACT_APP_FIREBASE_APP_ID: ${{ secrets.REACT_APP_FIREBASE_APP_ID }}
+      # Pin Node for the firebase-tools subprocess only: the runner default
+      # Node breaks node-fetch@v2 (premature close on every request), but the
+      # legacy react-snap/puppeteer in the build step needs the default Node.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.16.0
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.16.0
       - run: yarn
       - run: yarn build
         env:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -9,9 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24.16.0
       - run: yarn
       - run: yarn build
         env:
@@ -21,6 +18,12 @@ jobs:
           REACT_APP_FIREBASE_STORAGE_BUCKET: ${{ secrets.REACT_APP_FIREBASE_STORAGE_BUCKET }}
           REACT_APP_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.REACT_APP_FIREBASE_MESSAGING_SENDER_ID }}
           REACT_APP_FIREBASE_APP_ID: ${{ secrets.REACT_APP_FIREBASE_APP_ID }}
+      # Pin Node for the firebase-tools subprocess only: the runner default
+      # Node breaks node-fetch@v2 (premature close on every request), but the
+      # legacy react-snap/puppeteer in the build step needs the default Node.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.16.0
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -21,7 +21,7 @@ jobs:
       # Pin Node for the firebase-tools subprocess only: the runner default
       # Node breaks node-fetch@v2 (premature close on every request), but the
       # legacy react-snap/puppeteer in the build step needs the default Node.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.16.0
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.16.0
       - run: yarn
       - run: yarn build
         env:


### PR DESCRIPTION
## Summary

The `Deploy to Firebase Hosting on merge` job has been failing every run for days with:

```
The process '/usr/local/bin/npx' failed with exit code 1
```

### Root cause
- GitHub now forces the Actions runner onto a **Node 24.x** build that breaks `node-fetch@v2` (a `firebase-tools` dependency), producing a `Premature close` on **every** googleapis request (see firebase/firebase-tools#10684, nodejs/node#63989).
- `firebase-tools` retries each request. Idempotent calls succeed on retry, so the build/upload/finalize all pass.
- The final **non-idempotent** `POST .../channels/live/releases` succeeds server-side on attempt 1, but the response stream closes prematurely; the retry then returns `400 FAILED_PRECONDITION: ...is the current active version`, so the job exits 1.
- Net effect: the site actually deploys, but the workflow is marked failed.

### Fix
Pin Node to a known-good `24.16.0` via `actions/setup-node` before the build/deploy steps in both Firebase workflows, so the `firebase-tools` subprocess no longer hits the premature-close bug.

## Test plan
- [ ] `Deploy to Firebase Hosting on PR` check runs green on this PR
- [ ] After merge, `Deploy to Firebase Hosting on merge` completes successfully (exit 0)

Made with [Cursor](https://cursor.com)