### PR TITLE
fix(test): make getMultiplier interpolation test deterministic

### DIFF
--- a/.github/workflows/analysis-tests.yml
+++ b/.github/workflows/analysis-tests.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:

--- a/analysis/src/__tests__/get-multiplier.test.ts
+++ b/analysis/src/__tests__/get-multiplier.test.ts
@@ -71,8 +71,10 @@ describe("getMultiplier", () => {
     const newestDate = new Date(EXPANSION_RELEASE_DATE);
     newestDate.setDate(newestDate.getDate() + 30);
 
-    const quarterDate = new Date(EXPANSION_RELEASE_DATE);
-    quarterDate.setDate(quarterDate.getDate() + 7.5);
+    const quarterDate = new Date(
+      EXPANSION_RELEASE_DATE.getTime() +
+        0.25 * (newestDate.getTime() - EXPANSION_RELEASE_DATE.getTime())
+    );
 
     const deck: Deck = {
       ...mockDeck,


### PR DESCRIPTION
## Summary
- The `getMultiplier › should interpolate linearly between OLD_MULTIPLIER and NEW_MULTIPLIER` test was failing in CI (Analysis Tests).
- Root cause: the quarter date was built with `setDate(getDate() + 7.5)`, but `setDate` truncates to an integer, so it added **7 days** (0.233 of the window) while the assertion assumed **0.25**. Since `NEW_MULTIPLIER` grows with calendar time (derived from `new Date()` in `settings.ts`), this fixed offset eventually grew past the `toBeCloseTo(_, 1)` tolerance and broke the build.
- Fix: construct the quarter date at exactly 25% of the window using millisecond arithmetic, so `result` and `expectedMultiplier` share the identical fraction and the test is stable regardless of `NEW_MULTIPLIER`'s magnitude.

## Test plan
- [x] `yarn jest src/__tests__/get-multiplier.test.ts` -> 4/4 pass
- [ ] CI "Analysis Tests" green

Made with [Cursor](https://cursor.com)